### PR TITLE
core: rtw_xmit: gate scan_state TX-block by _FW_UNDER_SURVEY to prevent permanent TX stall

### DIFF
--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -6269,6 +6269,7 @@ bool rtw_xmit_ac_blocked(_adapter *adapter)
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
 	_adapter *iface;
+	struct mlme_priv *mlme;
 	struct mlme_ext_priv *mlmeext;
 	bool blocked = _FALSE;
 	int i;
@@ -6294,17 +6295,23 @@ bool rtw_xmit_ac_blocked(_adapter *adapter)
 
 	for (i = 0; i < dvobj->iface_nums; i++) {
 		iface = dvobj->padapters[i];
+		mlme = &iface->mlmepriv;
 		mlmeext = &iface->mlmeextpriv;
 
-		/* check scan state */
-		if (mlmeext_scan_state(mlmeext) != SCAN_DISABLE
+		/* check scan state — gated by _FW_UNDER_SURVEY to avoid permanent
+		 * TX stall when rtw_scan_timeout_handler clears the upper flag but
+		 * mlmeext->scan_state stays stuck in SCAN_PROCESS (race when scan
+		 * never reaches SCAN_COMPLETE handler that resets scan_state). */
+		if (check_fwstate(mlme, _FW_UNDER_SURVEY)
+			&& mlmeext_scan_state(mlmeext) != SCAN_DISABLE
 			&& mlmeext_scan_state(mlmeext) != SCAN_BACK_OP
 		) {
 			blocked = _TRUE;
 			goto exit;
 		}
 
-		if (mlmeext_scan_state(mlmeext) == SCAN_BACK_OP
+		if (check_fwstate(mlme, _FW_UNDER_SURVEY)
+			&& mlmeext_scan_state(mlmeext) == SCAN_BACK_OP
 			&& !mlmeext_chk_scan_backop_flags(mlmeext, SS_BACKOP_TX_RESUME)
 		) {
 			blocked = _TRUE;


### PR DESCRIPTION
## Summary

Fixes a permanent TX stall caused by a race between the upper-level (`mlmepriv._FW_UNDER_SURVEY`) and low-level (`mlmeextpriv.scan_state`) MLME state when a scan times out.

Same root cause and identical patch shape was also submitted to:
- [`aircrack-ng/rtl8812au`](https://github.com/aircrack-ng/rtl8812au) (referencing their open issue [#778](https://github.com/aircrack-ng/rtl8812au/issues/778) — "Radio scans introduce lag spikes")
- [`morrownr/8821au-20210708`](https://github.com/morrownr/8821au-20210708) (sister repo with shared MLME code)

## Root cause

`rtw_scan_timeout_handler()` (`core/rtw_mlme.c`) clears the upper-level `_FW_UNDER_SURVEY` flag and notifies cfg80211, but does **not** reset `mlmeext->scan_state`. The only place that resets `scan_state` to `SCAN_DISABLE` in the normal completion path is the `SCAN_COMPLETE` handler in `core/rtw_mlme_ext.c`, which a stalled scan never reaches.

After this race, `rtw_xmit_ac_blocked()` (`core/rtw_xmit.c`) permanently returns `_TRUE` for the scan-state check, blocking all TX. RX continues unaffected (no scan gate on the RX path), beacons arrive, the station stays associated — `wpa_supplicant` reports `COMPLETED`, signal is fine, but no traffic flows.

`wpa_cli reconnect` is the user-visible workaround because a full re-assoc goes through `init_mlme_ext_priv()` which unconditionally resets `scan_state` to `SCAN_DISABLE`.

## Fix

Gate the scan-state TX-block check by `_FW_UNDER_SURVEY`. If the upper layer no longer thinks a scan is in progress, do not block TX even if the low-level `scan_state` is stuck.

The new condition is **strictly a subset** of the old one — when both layers agree a scan is in progress, behaviour is unchanged. Defensive: doesn't touch the state machine, doesn't risk HW init inconsistency.

## Test environment

Tested on the 8821AU sister chip (8821au-20210708 fork). The 8812AU and 8821AU share `core/rtw_xmit.c` verbatim, so the fix applies identically. If a maintainer of this repo wants to verify on actual 8812AU hardware before merging, that's reasonable — the change is small and the code path identical.

| Layer state                                        | Old behaviour | New behaviour |
| -------------------------------------------------- | ------------- | ------------- |
| `_FW_UNDER_SURVEY=1`, `scan_state` ∉ {DISABLE, BACKOP} | block TX      | block TX (unchanged) |
| `_FW_UNDER_SURVEY=0`, `scan_state` ∉ {DISABLE, BACKOP} (the desync) | block TX (forever) | **don't block TX** |
| `_FW_UNDER_SURVEY=1`, `scan_state ∈ {DISABLE, BACKOP}` | don't block TX | don't block TX (unchanged) |
| `_FW_UNDER_SURVEY=0`, `scan_state = DISABLE`         | don't block TX | don't block TX (unchanged) |
