### PR TITLE
core: rtw_xmit: fix latent build error — _FW_UNDER_SURVEY -> WIFI_UNDER_SURVEY

### DIFF
--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -6298,11 +6298,11 @@ bool rtw_xmit_ac_blocked(_adapter *adapter)
 		mlme = &iface->mlmepriv;
 		mlmeext = &iface->mlmeextpriv;
 
-		/* check scan state — gated by _FW_UNDER_SURVEY to avoid permanent
+		/* check scan state — gated by WIFI_UNDER_SURVEY to avoid permanent
 		 * TX stall when rtw_scan_timeout_handler clears the upper flag but
 		 * mlmeext->scan_state stays stuck in SCAN_PROCESS (race when scan
 		 * never reaches SCAN_COMPLETE handler that resets scan_state). */
-		if (check_fwstate(mlme, _FW_UNDER_SURVEY)
+		if (check_fwstate(mlme, WIFI_UNDER_SURVEY)
 			&& mlmeext_scan_state(mlmeext) != SCAN_DISABLE
 			&& mlmeext_scan_state(mlmeext) != SCAN_BACK_OP
 		) {
@@ -6310,7 +6310,7 @@ bool rtw_xmit_ac_blocked(_adapter *adapter)
 			goto exit;
 		}
 
-		if (check_fwstate(mlme, _FW_UNDER_SURVEY)
+		if (check_fwstate(mlme, WIFI_UNDER_SURVEY)
 			&& mlmeext_scan_state(mlmeext) == SCAN_BACK_OP
 			&& !mlmeext_chk_scan_backop_flags(mlmeext, SS_BACKOP_TX_RESUME)
 		) {


### PR DESCRIPTION
## Summary

**Fixes broken Build CI on `main`.** PR #198 (the scan_state desync fix you merged on 2026-04-25) inadvertently introduced an undefined identifier into `core/rtw_xmit.c`, breaking every gcc-10/11/12 job since.

## Root cause

The patch I prepared for this fork copy-pasted the identifier from the aircrack-ng/rtl8812au tree. There it works because aircrack-ng has:

```c
// include/rtw_mlme.h (aircrack-ng tree)
#define _FW_UNDER_SURVEY    WIFI_SITE_MONITOR
```

This fork has **no `_FW_*` alias** — `include/rtw_mlme.h` exports `WIFI_UNDER_SURVEY` directly. Compiler error:

```
core/rtw_xmit.c:6509:41: error: '_FW_UNDER_SURVEY' undeclared
(first use in this function); did you mean 'WIFI_UNDER_SURVEY'?
```

Build CI run 24937185656 (right after PR #198 merge) shows the failure on all three Ubuntu 22.04 / gcc-10/11/12 jobs. The same break is present on the sister `8812au-20210820` fork (its CI is set up differently so the failure was silent there).

## Fix

Mechanical rename of the three references PR #198 added: `_FW_UNDER_SURVEY` → `WIFI_UNDER_SURVEY`. No behavioural change, the underlying constant is the same.

## Apology

This was my mistake — when preparing the morrownr/8821au-20210708 variant of PR #198 I copy-pasted the aircrack-ng identifier verbatim and didn't run a local build before pushing (no kernel-headers setup on my side at the time). I should have noticed the diff in macro names between the trees during cross-fork review. Sorry for the noise.

The companion fix for `8812au-20210820` is at https://github.com/morrownr/8812au-20210820/pull/{NUM} (will be opened right after this).

## Effect on other open PRs

After this lands, my open PRs #199 (P2P/WFD attr_len underflow) and #200 (USB submit-failure counter leak) should re-build cleanly — the failures on those PRs are inherited from broken `main`, not from their own changes.
